### PR TITLE
Routing setup using react-router-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "postcss": "^8.4.47",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^6.27.0",
         "tailwindcss": "^3.4.14"
       },
       "devDependencies": {
@@ -1792,6 +1793,14 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
+      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -5485,6 +5494,36 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
+      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+      "dependencies": {
+        "@remix-run/router": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
+      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "dependencies": {
+        "@remix-run/router": "1.20.0",
+        "react-router": "6.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postcss": "^8.4.47",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.27.0",
     "tailwindcss": "^3.4.14"
   },
   "devDependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,16 @@
 import React from "react";
 import { Navbar } from "./components/Navbar";
+import { Outlet } from "react-router-dom";
 
 const App = () => {
-  return <>
-    <Navbar/>
-  </>;
+  return (
+    <>
+      <Navbar />
+      <main>
+        <Outlet /> {/* Nested routes would be rendered here */}
+      </main>
+    </>
+  );
 };
 
 export default App;

--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -6,3 +6,7 @@
 .nav-options>li:hover {
     color: var(--medium-blue);
 }
+
+.custom-navlink {
+    text-decoration: none;
+}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,9 +1,12 @@
 import React, { useEffect, useState, useRef } from "react";
+import { NavLink } from "react-router-dom";
 import "./Navbar.css";
 
 export const Navbar = () => {
   const [showNavOptions, setShowNavOptions] = useState(false);
   const navOptionsRef = useRef(null);
+  const blue = "text-[var(--medium-blue)]";
+  const black = "text-[var(--charcoal-black)]";
 
   useEffect(() => {
     if (showNavOptions) {
@@ -28,11 +31,56 @@ export const Navbar = () => {
       ref={navOptionsRef}
       className="nav-options list-none hidden justify-evenly items-center flex-col w-full md:flex-row md:w-[70%] md:flex"
     >
-      <li className="p-2 md:p-0">Welcome</li>
-      <li className="p-2 md:p-0">My Journey</li>
-      <li className="p-2 md:p-0">My Learning Path</li>
-      <li className="p-2 md:p-0">Achienvements</li>
-      <li className="p-2 md:p-0">Tech Arsenal</li>
+      <li>
+        <NavLink
+          to="/"
+          className={({ isActive }) =>
+            `custom-navlink p-2 md:p-0 ${isActive ? blue : black}`
+          }
+        >
+          Welcome
+        </NavLink>
+      </li>
+      <li>
+        <NavLink
+          to="my-journey"
+          className={({ isActive }) =>
+            `custom-navlink p-2 md:p-0 ${isActive ? blue : black}`
+          }
+        >
+          My Journey
+        </NavLink>
+      </li>
+      <li>
+        <NavLink
+          to="my-learning-path"
+          className={({ isActive }) =>
+            `custom-navlink p-2 md:p-0 ${isActive ? blue : black}`
+          }
+        >
+          My Learning Path
+        </NavLink>
+      </li>
+      <li>
+        <NavLink
+          to="achievements"
+          className={({ isActive }) =>
+            `custom-navlink p-2 md:p-0 ${isActive ? blue : black}`
+          }
+        >
+          Achienvements
+        </NavLink>
+      </li>
+      <li>
+        <NavLink
+          to="tech-arsenal"
+          className={({ isActive }) =>
+            `custom-navlink p-2 md:p-0 ${isActive ? blue : black}`
+          }
+        >
+          Tech Arsenal
+        </NavLink>
+      </li>
     </ul>
   );
 

--- a/src/config/routing.js
+++ b/src/config/routing.js
@@ -1,0 +1,33 @@
+import React from "react";
+import { createBrowserRouter } from "react-router-dom";
+import App from "../App";
+import Home from "../pages/Home";
+import MyJourney from "../pages/MyJourney";
+import MyLearningPath from "../pages/MyLearningPath";
+import ErrorPage from "../pages/ErrorPage";
+
+const config = [
+  {
+    path: "/",
+    element: <App />,
+    children: [
+      {
+        path: "/",
+        element: <Home />,
+      },
+      {
+        path: "/my-journey",
+        element: <MyJourney />,
+      },
+      {
+        path: "/my-learning-path",
+        element: <MyLearningPath />,
+      },
+    ],
+    errorElement: <ErrorPage/>
+  },
+];
+
+const appRouter = createBrowserRouter(config);
+
+export default appRouter;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./styles.css";
-import App from "./App";
+import { RouterProvider } from "react-router-dom";
+import appRouter from "./config/routing";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(<App />);
+root.render(<RouterProvider router={appRouter} />);

--- a/src/pages/ErrorPage.js
+++ b/src/pages/ErrorPage.js
@@ -1,0 +1,5 @@
+const ErrorPage = () => {
+  return "Error Page!";
+};
+
+export default ErrorPage;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,0 +1,5 @@
+const Home = () => {
+  return "Home Page!";
+};
+
+export default Home;

--- a/src/pages/MyJourney.js
+++ b/src/pages/MyJourney.js
@@ -1,0 +1,5 @@
+const MyJourney = () => {
+  return "My Journey Page!";
+};
+
+export default MyJourney;

--- a/src/pages/MyLearningPath.js
+++ b/src/pages/MyLearningPath.js
@@ -1,0 +1,5 @@
+const MyLearningPath = () => {
+  return "My Learning Path Page!";
+};
+
+export default MyLearningPath;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
     static: "./dist",
     host: "localhost",
     port: 3000,
+    historyApiFallback: true, // Enable this for client-side routing support
     open: true,
     hot: true,
   },


### PR DESCRIPTION
Used lts version of react-router-dom, so there is a change in syntax and how it has been configured compared to older versions.

`historyApiFallback: true, // Enable this for client-side routing support`

The above line of code was added to webpack config file so that client side routing would be supported (it will not come to server looking for pages similar to path requested).